### PR TITLE
Initial leave git repo in plugins

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -110,6 +110,12 @@ class InstallCommand extends Command
         $this->composer->setOutput($output);
     }
 
+    public function setWithGitDirectory(bool $withGitDirectory)
+    {
+        $this->pluginManager->setWithGitDirectory($withGitDirectory);
+        $this->themeManager->setWithGitDirectory($withGitDirectory);
+    }
+
     /**
      * Configure the command options.
      *
@@ -140,6 +146,11 @@ class InstallCommand extends Command
                 InputOption::VALUE_OPTIONAL,
                 'Specify from where to fetch template files (git remote)',
                 ''
+            )->addOption(
+                'with-git-directory',
+                null,
+                InputOption::VALUE_NONE,
+                'Specify whether or not to delete .git directories'
             );
     }
 
@@ -163,6 +174,7 @@ class InstallCommand extends Command
         }
 
         $this->setOutput($output);
+        $this->setWithGitDirectory($input->getOption('with-git-directory'));
 
         $this->force = $input->getOption('force');
 

--- a/src/Manager/BaseManager.php
+++ b/src/Manager/BaseManager.php
@@ -29,6 +29,11 @@ class BaseManager
      */
     protected $php;
 
+    /**
+     * @var bool
+     */
+    protected $withGitDirectory = false;
+
     public function __construct()
     {
         $this->artisan = new Artisan();
@@ -45,5 +50,18 @@ class BaseManager
     {
         $this->php = $php;
         $this->artisan->setPhp($php);
+    }
+
+    /**
+     * Set if remove .git directories or not
+     */
+    public function setWithGitDirectory(bool $withGitDirectory = false)
+    {
+        $this->withGitDirectory = $withGitDirectory;
+    }
+
+    public function isWithGitDirectory(): bool
+    {
+        return $this->withGitDirectory;
     }
 }

--- a/src/Manager/PluginManager.php
+++ b/src/Manager/PluginManager.php
@@ -140,7 +140,9 @@ class PluginManager extends BaseManager
             throw new RuntimeException('Error while cloning plugin repo: ' . $e->getMessage());
         }
 
-        $this->removeGitRepo($this->getDirPath($pluginDeclaration));
+        if(!$this->isWithGitDirectory()) {
+            $this->removeGitRepo($this->getDirPath($pluginDeclaration));
+        }
     }
 
     /**

--- a/src/Manager/ThemeManager.php
+++ b/src/Manager/ThemeManager.php
@@ -92,7 +92,9 @@ class ThemeManager extends BaseManager
             throw new RuntimeException('Error while cloning theme repo: ' . $e->getMessage());
         }
 
-        $this->removeGitRepo($themeDir);
+        if(!$this->isWithGitDirectory()) {
+            $this->removeGitRepo($themeDir);
+        }
 
         return true;
     }


### PR DESCRIPTION
I was thinking about something like this:

![image](https://user-images.githubusercontent.com/8854428/91564854-8ca52280-e941-11ea-92b8-cbb82d261faf.png)

under git:, something like `persistRepositories`.

But after a while, I think the console parameter may be a good idea as well. We can toggle in our environment whether we want or not to remove the repo. Just thinking out loud. 